### PR TITLE
Fix to openstack-helm-infra/+bug/1783424

### DIFF
--- a/playbooks/osh-infra-build.yaml
+++ b/playbooks/osh-infra-build.yaml
@@ -23,7 +23,7 @@
   tags:
     - build-helm-packages
 
-- hosts: all
+- hosts: primary
   vars_files:
     - vars.yaml
   vars:


### PR DESCRIPTION
Docker build task should only be executed on k8s master node.
With this commit we are fixing inventory file with the correct
hostgroup to execute docker build command