### PR TITLE
fix yaml syntax error in mariadb-services-tcp

### DIFF
--- a/mariadb/templates/configmap-services-tcp.yaml
+++ b/mariadb/templates/configmap-services-tcp.yaml
@@ -20,5 +20,5 @@ kind: ConfigMap
 metadata:
   name: mariadb-services-tcp
 data:
-  {{ tuple "oslo_db" "internal" "mysql" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}: "{{ .Release.Namespace }}/{{ tuple "oslo_db" "direct" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}:{{ tuple "oslo_db" "direct" "mysql" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}"
+  "{{ tuple "oslo_db" "internal" "mysql" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}": "{{ .Release.Namespace }}/{{ tuple "oslo_db" "direct" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}:{{ tuple "oslo_db" "direct" "mysql" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}"
 {{- end }}

--- a/mariadb/templates/monitoring/prometheus/exporter-deployment.yaml
+++ b/mariadb/templates/monitoring/prometheus/exporter-deployment.yaml
@@ -39,7 +39,6 @@ spec:
 {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" | indent 8 }}
 {{ dict "envAll" $envAll "podName" "prometheus-mysql-exporter" "containerNames" (list "init" "mysql-exporter") | include "helm-toolkit.snippets.kubernetes_mandatory_access_control_annotation" | indent 8 }}
     spec:
-{{ dict "envAll" $envAll "application" "mysql_exporter" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}
       shareProcessNamespace: true
       serviceAccountName: {{ $serviceAccountName }}
 {{ dict "envAll" $envAll "application" "prometheus_mysql_exporter" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}


### PR DESCRIPTION
fix yaml syntax error that prevents the usage of  kustomize

```
Error: map[string]interface {}{"apiVersion":"v1", "data":map[interface {}]interface {}{3306:"openstack/mariadb-server:3306"}, "kind":"ConfigMap", "metadata":map[string]interface {}{"name":"mariadb-services-tcp", "namespace":"openstack"}}: json: unsupported type: map[interface {}]interface {}
```