### PR TITLE
Fix typo for node-selector

### DIFF
--- a/rabbitmq/templates/job-cluster-wait.yaml
+++ b/rabbitmq/templates/job-cluster-wait.yaml
@@ -60,7 +60,7 @@ spec:
 {{ tuple $envAll "rabbitmq" | include "helm-toolkit.snippets.kubernetes_tolerations" | indent 6 }}
 {{ end }}
       nodeSelector:
-        {{ $envAll.Values.labels.jobs.node_selector_key }}: {{ $envAll.Values.labels.test.node_selector_value | quote }}
+        {{ $envAll.Values.labels.jobs.node_selector_key }}: {{ $envAll.Values.labels.jobs.node_selector_value | quote }}
       initContainers:
 {{ tuple $envAll "cluster_wait" list | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
         - name: rabbitmq-cookie


### PR DESCRIPTION
- Fix typo in the nodeSelector of the wait-cluster job template for rabbitmq